### PR TITLE
Updated to support updated skill/attribute storage now in corescripts

### DIFF
--- a/0.7/flatModifiers.lua
+++ b/0.7/flatModifiers.lua
@@ -1,4 +1,4 @@
--- flatModifiers (Advanced) - Release 2 - For tes3mp v0.7-prerelease Requires classInfo.
+-- flatModifiers (Advanced) - Release 2.1 - For tes3mp v0.7-prerelease Requires classInfo.
 
 --[[ INSTALLATION
 1) Save this file as "flatModifiers.lua" in mp-stuff/scripts
@@ -38,7 +38,7 @@ config.classAttributeBonus = 3 -- How many skill advances get added to an attrib
 local function basicMode(pid)
 	for i = 0, 7 do
 		if i ~= 7 or config.includeLuck then --Avoid giving Luck (7) any bonus, unless configured to
-			Players[pid].data.attributeSkillIncreases[tes3mp.GetAttributeName(i)] = config.basicAttributeIncreases
+			Players[pid].data.attributes[tes3mp.GetAttributeName(i)].skillIncrease = config.basicAttributeIncreases
 		end
 	end
 	Players[pid]:LoadAttributes()
@@ -72,7 +72,7 @@ local function classMode(pid)
 		if i ~= 7 or config.includeLuck then --Avoid giving Luck (7) any bonus, unless configured to
 			local amount = config.classBase + (changes[i] or 0)
 			amount = math.min(math.floor(amount), 10)
-			Players[pid].data.attributeSkillIncreases[tes3mp.GetAttributeName(i)] = amount
+			Players[pid].data.attributes[tes3mp.GetAttributeName(i)].skillIncrease = amount
 		end
 	end
 	


### PR DESCRIPTION
This is an very small fix to flatmodifiers to support the new system for storing skill/attribute introduced by this commit to corescripts in march

https://github.com/TES3MP/CoreScripts/commit/0f8d1134950fb089b305724a1d5a0cf3dc550c0d

I have tested this and it seems to work as intended.